### PR TITLE
Run windows tests in multiple shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,4 +144,4 @@ jobs:
       run: make setup
 
     - name: Run the test suite
-      run: make test
+      run: uv run duty --capture=none test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,43 @@ jobs:
 
     - name: Run the test suite
       run: uv run pytest
+
+    - name: Passing smoke test capture both
+      if: '!cancelled()'
+      run: uv run tests/smoketest.py passing both
+
+    - name: Failing smoke test capture both
+      if: '!cancelled()'
+      run: uv run tests/smoketest.py failing both
+
+    - name: Passing smoke test capture none
+      if: '!cancelled()'
+      run: uv run tests/smoketest.py passing none
+
+    - name: Failing smoke test capture none
+      if: '!cancelled()'
+      run: uv run tests/smoketest.py failing none
+
+    - name: Passing smoke test capture both with legacy stdio
+      if: '!cancelled()'
+      env:
+        PYTHONLEGACYWINDOWSSTDIO: 1
+      run: uv run tests/smoketest.py passing both
+
+    - name: Failing smoke test capture both with legacy stdio
+      if: '!cancelled()'
+      env:
+        PYTHONLEGACYWINDOWSSTDIO: 1
+      run: uv run tests/smoketest.py failing both
+
+    - name: Passing smoke test capture none with legacy stdio
+      if: '!cancelled()'
+      env:
+        PYTHONLEGACYWINDOWSSTDIO: 1
+      run: uv run tests/smoketest.py passing none
+
+    - name: Failing smoke test capture none with legacy stdio
+      if: '!cancelled()'
+      env:
+        PYTHONLEGACYWINDOWSSTDIO: 1
+      run: uv run tests/smoketest.py failing none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,45 @@ jobs:
 
     - name: Run the test suite
       run: make test
+
+  tests-pwsh:
+    defaults:
+      run:
+        shell: pwsh
+    strategy:
+      matrix:
+        os:
+        - windows-latest
+        python-version:
+        - "3.13"
+        resolution:
+        - highest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+        cache-dependency-glob: pyproject.toml
+        cache-suffix: py${{ matrix.python-version }}
+
+    - name: Install dependencies
+      env:
+        UV_RESOLUTION: ${{ matrix.resolution }}
+      run: make setup
+
+    - name: Run the test suite
+      run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,7 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
         - "3.13"
-        - "3.14"
         resolution:
         - highest
         - lowest-direct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,4 +144,4 @@ jobs:
       run: make setup
 
     - name: Run the test suite
-      run: uv run duty --capture=none test
+      run: uv run pytest

--- a/src/failprint/capture.py
+++ b/src/failprint/capture.py
@@ -113,7 +113,7 @@ class CaptureManager:
         self._saved_stdout_fd: int = -1
         self._saved_stderr_fd: int = -1
         self._output: str | None = None
-        self._old_env: dict[str, str] = {}
+        self._old_env: dict[str, str | None] = {}
 
     def __enter__(self) -> CaptureManager:  # noqa: PYI034 (false-positive)
         # Annoying operating system being annoying again.

--- a/src/failprint/capture.py
+++ b/src/failprint/capture.py
@@ -119,8 +119,8 @@ class CaptureManager:
         # Annoying operating system being annoying again.
         # Bash ports and WSL2 work fine, this environment variable
         # just helps a bit with cmd and PowerShell.
-        self._old_env["PYTHONLEGACYWINDOWSSTDIO"] = os.getenv("PYTHONLEGACYWINDOWSSTDIO")
-        os.environ["PYTHONLEGACYWINDOWSSTDIO"] = "1"
+        #self._old_env["PYTHONLEGACYWINDOWSSTDIO"] = os.getenv("PYTHONLEGACYWINDOWSSTDIO")
+        #os.environ["PYTHONLEGACYWINDOWSSTDIO"] = "1"
 
         if self._capture is Capture.NONE:
             return self

--- a/tests/smoketest.py
+++ b/tests/smoketest.py
@@ -1,0 +1,15 @@
+import failprint
+import sys
+import time
+
+def passing():
+    time.sleep(1)
+    print("I'm passing")
+    return 0
+
+def failing():
+    time.sleep(1)
+    print("I'm failing")
+    return 1
+
+failprint.run(vars()[sys.argv[1]], capture=sys.argv[2])

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -345,8 +345,9 @@ def test_capture_function_and_subprocess_output(capsys: pytest.CaptureFixture) -
     """
 
     def function() -> None:
-        print("print")
+        print("print", flush=True)
         sys.stdout.write("sys stdout write\n")
+        sys.stdout.flush()
         os.system("echo os system")  # noqa: S605,S607
         subprocess.run(["sh", "-c", "echo sh -c echo"], check=False)  # noqa: S603,S607
 


### PR DESCRIPTION
From https://github.com/pawamoy/duty/issues/23, which identified problems running failprint on Windows, specifically when _not_ run under a bash-like shell.

The current CI builds run the Windows tests using git bash and so don't surface the problem.